### PR TITLE
Popcop protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ The UAVCAN protocol support requires the following libraries:
 The Popcop protocol support requires the following libraries:
 
 * [Libpopcop](https://github.com/Zubax/popcop) - implementation of the Popcop protocol in C++.
-* [Senoval](https://github.com/Zubax/senoval) - utility library for deeply embedded systems.
 
 ## License
 

--- a/kocherga_popcop.hpp
+++ b/kocherga_popcop.hpp
@@ -289,6 +289,7 @@ class PopcopProtocol final : private kocherga::IProtocol
         case popcop::standard::BootloaderState::NoAppToBoot:
         case popcop::standard::BootloaderState::BootDelay:
         {
+            sendBootloaderStatusResponse();     // Send response anyway!
             break;
         }
 

--- a/kocherga_popcop.hpp
+++ b/kocherga_popcop.hpp
@@ -1,0 +1,480 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Zubax Robotics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+ */
+
+#pragma once
+
+#include <kocherga.hpp>
+
+// Third-party dependencies:
+#include <popcop.hpp>                   // Popcop protocol implementation in C++
+#include <senoval/string.hpp>           // Utility library for embedded systems
+#include <senoval/vector.hpp>           // Utility library for embedded systems
+#include <utility>
+
+
+namespace kocherga_popcop
+{
+/**
+ * Platform abstraction interface for the Popcop protocol.
+ */
+class IPopcopPlatform
+{
+public:
+    /**
+     * Serial port input/output methods should return if the IO operation could not be completed in this amount of time.
+     */
+    static constexpr std::chrono::microseconds IOByteTimeout{1'000};   // NOLINT
+
+    /**
+     * This constant is implicitly defined by Popcop. The protocol does not support CoA longer than this.
+     */
+    static constexpr std::uint8_t CertificateOfAuthenticityMaxLength = 255;
+
+    virtual ~IPopcopPlatform() = default;
+
+    /**
+     * Sends one byte to the opposite endpoint.
+     * If timed out, do nothing. @ref IOByteTimeout
+     */
+    virtual void emit(std::uint8_t byte) = 0;
+
+    /**
+     * Receives one byte from the serial port input buffer.
+     * If timed out, returns an empty option. @ref IOByteTimeout
+     */
+    virtual std::optional<std::uint8_t> receive() = 0;
+
+    /**
+     * This method is invoked when the endpoint encounters a frame that it doesn't know how to process.
+     * The application may opt to handle such frames itself.
+     * The default implementation does nothing.
+     */
+    virtual void processUnhandledFrame(const popcop::transport::ParserOutput::Frame& frame)
+    {
+        (void) frame;
+    }
+
+    /**
+     * This method is invoked when the local endpoint encounters unparsed data in the stream.
+     * The application may opt to handle it in some way or print it.
+     * The default implementation does nothing.
+     */
+    virtual void processExtraneousData(const std::uint8_t* data, std::size_t length)
+    {
+        (void) data;
+        (void) length;
+    }
+
+    /**
+     * This method is invoked when the local endpoint receives a device management command that it can't handle.
+     * Currently, only the following device management commands are handled by the endpoint, all others are delegated
+     * to the application via this method:
+     *  - LaunchBootloader (does nothing)
+     */
+    virtual popcop::standard::DeviceManagementCommandResponseMessage::Status processUnhandledDeviceManagementCommand(
+        const popcop::standard::DeviceManagementCommandRequestMessage& request) = 0;
+
+    /**
+     * This method, if implemented, must atomically write the certificate of authenticity into some kind of ROM,
+     * and then read it back. The supplied data to write is pointed to by in_data, and the output data is pointed to
+     * by out_data.
+     * The return value is the length of out_data or a negative error code.
+     * The length of CoA can never exceed 255 bytes.
+     * If the target platform does not support CoA storage, leave this method unimplemented.
+     */
+    virtual std::int16_t writeAndReadBackCertificateOfAuthenticity(const std::uint8_t* in_data,
+                                                                   std::uint8_t* out_data,
+                                                                   std::uint8_t length)
+    {
+        (void) in_data;
+        (void) out_data;
+        (void) length;
+        return 0;
+    }
+
+    /**
+     * This method is invoked by the endpoint's thread periodically as long as it functions properly.
+     * The application can use it to reset a watchdog, but it is not mandatory.
+     * The minimal watchdog timeout is 3 seconds! Lower values may trigger spurious resets.
+     */
+    virtual void resetWatchdog() = 0;
+
+    /**
+     * This method is invoked by the endpoint periodically to check if it should terminate.
+     */
+    virtual bool shouldExit() const = 0;
+};
+
+/**
+ * Popcop bootloader endpoint implementation.
+ * Either instantiate one instance per available port, or switch the same instance between available ports.
+ */
+class PopcopProtocol final : private kocherga::IProtocol
+{
+    ::kocherga::BootloaderController& blc_;
+    IPopcopPlatform& platform_;
+    const popcop::standard::NodeInfoMessage node_info_prototype_;
+
+    popcop::transport::Parser<> parser_{};
+
+    kocherga::IDownloadSink* download_sink_ = nullptr;
+    bool download_image_reached_ = false;
+    std::int16_t upgrade_status_code_ = 0;
+
+
+    // Sends out one frame, ignores errors
+    template <typename M>
+    void send(const M& message)
+    {
+        struct
+        {
+            IPopcopPlatform* pl_;
+            void operator()(std::uint8_t byte)
+            {
+                pl_->emit(byte);
+            }
+        }
+        sender
+        {
+            &platform_
+        };
+        (void) message.encode(popcop::transport::StreamEmitter(popcop::presentation::StandardFrameTypeCode,
+                                                               sender).begin());
+    }
+
+    void processNodeInfoRequest()
+    {
+        popcop::standard::NodeInfoMessage m = node_info_prototype_;
+        if (const auto ai = blc_.getAppInfo())
+        {
+            auto& sw = m.software_version;
+            sw.major         = ai->major_version;
+            sw.minor         = ai->minor_version;
+            sw.vcs_commit_id = ai->vcs_commit;
+            sw.image_crc     = ai->image_crc;
+            sw.release_build = ai->isReleaseBuild();
+            sw.dirty_build   = ai->isDirtyBuild();
+            sw.build_timestamp_utc = ai->isBuildTimestampValid() ? ai->build_timestamp_utc : 0;
+        }
+
+        send(m);
+    }
+
+    void processDeviceManagementCommandRequest(const popcop::standard::DeviceManagementCommandRequestMessage& req)
+    {
+        popcop::standard::DeviceManagementCommandResponseMessage resp{};
+        resp.command = req.command;
+
+        if (req.command == popcop::standard::DeviceManagementCommand::LaunchBootloader)
+        {
+            // Do nothing - we're already in the bootloader!
+            resp.status = popcop::standard::DeviceManagementCommandResponseMessage::Status::Ok;
+        }
+        else
+        {
+            resp.status = platform_.processUnhandledDeviceManagementCommand(req);
+        }
+
+        send(resp);
+    }
+
+    void sendBootloaderStatusResponse()
+    {
+        popcop::standard::BootloaderStatusResponseMessage resp{};
+        resp.timestamp = blc_.getMonotonicUptime();
+
+        switch (blc_.getState())
+        {
+        case kocherga::State::NoAppToBoot:
+        {
+            assert(download_sink_ == nullptr);
+            resp.state = popcop::standard::BootloaderState::NoAppToBoot;
+            break;
+        }
+        case kocherga::State::BootDelay:
+        {
+            assert(download_sink_ == nullptr);
+            resp.state = popcop::standard::BootloaderState::BootDelay;
+            break;
+        }
+        case kocherga::State::BootCancelled:
+        {
+            assert(download_sink_ == nullptr);
+            resp.state = popcop::standard::BootloaderState::BootCancelled;
+            break;
+        }
+        case kocherga::State::AppUpgradeInProgress:
+        {
+            assert(download_sink_ != nullptr);
+            resp.state = popcop::standard::BootloaderState::AppUpgradeInProgress;
+            break;
+        }
+        case kocherga::State::ReadyToBoot:
+        {
+            assert(download_sink_ == nullptr);
+            resp.state = popcop::standard::BootloaderState::ReadyToBoot;
+            break;
+        }
+        }
+
+        send(resp);
+    }
+
+    void processBootloaderStatusRequest(const popcop::standard::BootloaderStatusRequestMessage& req)
+    {
+        switch (req.desired_state)
+        {
+        case popcop::standard::BootloaderState::BootCancelled:
+        {
+            blc_.cancelBoot();
+            sendBootloaderStatusResponse();
+            break;
+        }
+
+        case popcop::standard::BootloaderState::AppUpgradeInProgress:
+        {
+            if (download_sink_ == nullptr)
+            {
+                download_image_reached_ = false;
+                upgrade_status_code_ = 0;
+
+                // This function blocks for a long time; it will send the response itself
+                (void) blc_.upgradeApp(*this);
+
+                if (!download_image_reached_)       // Response has not been sent, do it now
+                {
+                    sendBootloaderStatusResponse();
+                }
+            }
+            else
+            {
+                sendBootloaderStatusResponse();     // We're already upgrading, do nothing
+            }
+            break;
+        }
+
+        case popcop::standard::BootloaderState::ReadyToBoot:
+        {
+            blc_.requestBoot();
+            sendBootloaderStatusResponse();
+            break;
+        }
+
+        case popcop::standard::BootloaderState::NoAppToBoot:
+        case popcop::standard::BootloaderState::BootDelay:
+        {
+            break;
+        }
+        }
+    }
+
+    void processBootloaderImageDataRequest(const popcop::standard::BootloaderImageDataRequestMessage& req)
+    {
+        popcop::standard::BootloaderImageDataResponseMessage resp{};
+        resp.image_offset = req.image_offset;
+        resp.image_type   = req.image_type;
+
+        switch (req.image_type)
+        {
+        case popcop::standard::BootloaderImageType::Application:
+        {
+            if (download_sink_ != nullptr)
+            {
+                // Observe that we ignore the offset here! The protocol requires that the offset must grow sequentially.
+                // If it doesn't, the downloaded image will be invalid; the bootloader controller will catch that later.
+                if (!req.image_data.empty())
+                {
+                    const auto result = download_sink_->handleNextDataChunk(req.image_data.data(),
+                                                                            std::uint16_t(req.image_data.size()));
+                    if (result >= 0)
+                    {
+                        resp.image_data = req.image_data;
+                        upgrade_status_code_ = 0;
+                    }
+                    else
+                    {
+                        upgrade_status_code_ = result;
+                    }
+                }
+
+                if (req.image_data.size() < req.image_data.max_size())
+                {
+                    // Last chunk received, terminate
+                    download_sink_ = nullptr;
+                }
+            }
+        }
+
+        case popcop::standard::BootloaderImageType::CertificateOfAuthenticity:
+        {
+            if ((req.image_offset == 0) &&
+                (req.image_data.size() < IPopcopPlatform::CertificateOfAuthenticityMaxLength))
+            {
+                resp.image_data.resize(resp.image_data.max_size());
+                const auto result =
+                    platform_.writeAndReadBackCertificateOfAuthenticity(req.image_data.data(),
+                                                                        resp.image_data.data(),
+                                                                        std::uint8_t(req.image_data.size()));
+                if (result >= 0)
+                {
+                    resp.image_data.resize(std::size_t(result));
+                }
+                else
+                {
+                    resp.image_data.clear();
+                }
+            }
+            else
+            {
+                ;   // Invalid request, return empty
+            }
+            break;
+        }
+        }
+
+        send(resp);
+    }
+
+    void processFrame(const popcop::transport::ParserOutput::Frame& frame)
+    {
+        if (frame.type_code == popcop::presentation::StandardFrameTypeCode)
+        {
+            const auto& payload = frame.payload;
+
+            if (popcop::standard::NodeInfoMessage::tryDecode(payload.begin(),
+                                                             payload.end()))
+            {
+                processNodeInfoRequest();
+            }
+            else if (auto dmcr = popcop::standard::DeviceManagementCommandRequestMessage::tryDecode(payload.begin(),
+                                                                                                    payload.end()))
+            {
+                processDeviceManagementCommandRequest(*dmcr);
+            }
+            else if (auto bsr = popcop::standard::BootloaderStatusRequestMessage::tryDecode(payload.begin(),
+                                                                                            payload.end()))
+            {
+                processBootloaderStatusRequest(*bsr);
+            }
+            else if (auto bidr = popcop::standard::BootloaderImageDataRequestMessage::tryDecode(payload.begin(),
+                                                                                                payload.end()))
+            {
+                processBootloaderImageDataRequest(*bidr);
+            }
+            else
+            {
+                platform_.processUnhandledFrame(frame);
+            }
+        }
+        else
+        {
+            platform_.processUnhandledFrame(frame);
+        }
+    }
+
+    void processByte(std::uint8_t byte)
+    {
+        const auto out = parser_.processNextByte(byte);
+        if (auto frame = out.getReceivedFrame())
+        {
+            platform_.resetWatchdog();
+            processFrame(*frame);
+            platform_.resetWatchdog();
+        }
+        else if (auto ed = out.getExtraneousData())
+        {
+            platform_.resetWatchdog();
+            platform_.processExtraneousData(ed->data(), ed->size());
+            platform_.resetWatchdog();
+        }
+        else
+        {
+            ;
+        }
+    }
+
+    void loopOnce()
+    {
+        platform_.resetWatchdog();
+        if (const auto res = platform_.receive())
+        {
+            processByte(*res);
+        }
+    }
+
+    std::int16_t downloadImage(kocherga::IDownloadSink& sink) final
+    {
+        assert(!download_image_reached_);
+        assert(download_sink_ == nullptr);
+        assert(upgrade_status_code_ == 0);
+
+        download_sink_ = &sink;
+
+        download_image_reached_ = true;
+        sendBootloaderStatusResponse();
+
+        while (!platform_.shouldExit() &&
+               (download_sink_ != nullptr) &&
+               (upgrade_status_code_ >= 0))
+        {
+            loopOnce();
+        }
+
+        download_sink_ = nullptr;
+        return upgrade_status_code_;
+    }
+
+    static popcop::standard::NodeInfoMessage prepareNodeInfoMessage(popcop::standard::NodeInfoMessage prototype)
+    {
+        prototype.software_version = popcop::standard::NodeInfoMessage::SoftwareVersion();
+        prototype.mode = popcop::standard::NodeInfoMessage::Mode::Bootloader;
+        return prototype;
+    }
+
+public:
+    PopcopProtocol(::kocherga::BootloaderController& bootloader_controller,
+                   IPopcopPlatform& popcop_platform,
+                   const popcop::standard::NodeInfoMessage& ni) :
+        blc_(bootloader_controller),
+        platform_(popcop_platform),
+        node_info_prototype_(prepareNodeInfoMessage(ni))
+    { }
+
+    /**
+     * Runs the endpoint thread.
+     * This function never returns unless IPopcopPlatform::shouldExit() returns true.
+     * If an RTOS is available, it is advisable to run this method from a separate thread.
+     * Otherwise, it is possible to perform other tasks by hijacking certain platform API functions.
+     */
+    void run()
+    {
+        while (!platform_.shouldExit())
+        {
+            loopOnce();
+        }
+    }
+};
+
+}  // namespace kocherga_popcop

--- a/kocherga_popcop.hpp
+++ b/kocherga_popcop.hpp
@@ -29,8 +29,6 @@
 
 // Third-party dependencies:
 #include <popcop.hpp>                   // Popcop protocol implementation in C++
-#include <senoval/string.hpp>           // Utility library for embedded systems
-#include <senoval/vector.hpp>           // Utility library for embedded systems
 #include <utility>
 
 

--- a/kocherga_popcop.hpp
+++ b/kocherga_popcop.hpp
@@ -384,16 +384,19 @@ class PopcopProtocol final : private kocherga::IProtocol
             if (popcop::standard::EndpointInfoMessage::tryDecode(payload.begin(),
                                                                  payload.end()))
             {
+                KOCHERGA_TRACE("Popcop: EP info req\n");
                 processEndpointInfoRequest();
             }
             else if (auto dmcr = popcop::standard::DeviceManagementCommandRequestMessage::tryDecode(payload.begin(),
                                                                                                     payload.end()))
             {
+                KOCHERGA_TRACE("Popcop: Device mgmt cmd\n");
                 processDeviceManagementCommandRequest(*dmcr);
             }
             else if (auto bsr = popcop::standard::BootloaderStatusRequestMessage::tryDecode(payload.begin(),
                                                                                             payload.end()))
             {
+                KOCHERGA_TRACE("Popcop: Bootloader status req\n");
                 processBootloaderStatusRequest(*bsr);
             }
             else if (auto bidr = popcop::standard::BootloaderImageDataRequestMessage::tryDecode(payload.begin(),
@@ -403,11 +406,13 @@ class PopcopProtocol final : private kocherga::IProtocol
             }
             else
             {
+                KOCHERGA_TRACE("Popcop: Unhandled std frame\n");
                 platform_.processUnhandledFrame(frame);
             }
         }
         else
         {
+            KOCHERGA_TRACE("Popcop: Unhandled app frame type %u\n", frame.type_code);
             platform_.processUnhandledFrame(frame);
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,10 @@ if(NOT CMAKE_BUILD_TYPE)
         FORCE)
 endif()
 
-include_directories(.. . senoval)
+include_directories(..
+                    .
+                    senoval
+                    popcop/c++)
 
 # Using 32-bit mode for compatibility with libcanard
 # Enabling all warnings; make them fatal for C++ and non-fatal for C (because C is only needed for dependencies)

--- a/test/images.hpp
+++ b/test/images.hpp
@@ -40,7 +40,10 @@ namespace images
  */
 static constexpr std::uint8_t AppValidMajorVersion = 0;
 static constexpr std::uint8_t AppValidMinorVersion = 1;
-static constexpr std::uint32_t AppValidVCSCommit   = 0x5378b66fUL;
+static constexpr std::uint32_t AppValidVCSCommit      = 0x5378b66fUL;
+static constexpr std::uint32_t AppValidBuildTimestamp = 0xFFFFFFFFUL;
+static constexpr bool AppValidReleaseBuild = true;
+static constexpr bool AppValidDirtyBuild = true;
 static constexpr std::array<std::uint8_t, 1024> AppValid{{
     0x00, 0x10, 0x00, 0x20, 0x61, 0xc3, 0x00, 0x08, 0x71, 0x45, 0x02, 0x08, 0x61, 0x45, 0x02, 0x08,
     0x51, 0x45, 0x02, 0x08, 0x41, 0x45, 0x02, 0x08, 0x31, 0x45, 0x02, 0x08, 0x62, 0xc3, 0x00, 0x08,
@@ -185,6 +188,9 @@ static constexpr std::array<std::uint8_t, 1024> AppWithInvalidDescriptor{{
 static constexpr std::uint8_t AppValid2MajorVersion = 0;
 static constexpr std::uint8_t AppValid2MinorVersion = 1;
 static constexpr std::uint32_t AppValid2VCSCommit   = 0x5378b66fUL;
+static constexpr std::uint32_t AppValid2BuildTimestamp = 0xFFFFFFFFUL;
+static constexpr bool AppValid2ReleaseBuild = true;
+static constexpr bool AppValid2DirtyBuild = true;
 static constexpr std::array<std::uint8_t, 10504> AppValid2{{
     0x00, 0x10, 0x00, 0x20, 0x61, 0xc3, 0x00, 0x08, 0x71, 0x45, 0x02, 0x08, 0x61, 0x45, 0x02, 0x08,
     0x51, 0x45, 0x02, 0x08, 0x41, 0x45, 0x02, 0x08, 0x31, 0x45, 0x02, 0x08, 0x62, 0xc3, 0x00, 0x08,

--- a/test/test_core.cpp
+++ b/test/test_core.cpp
@@ -169,6 +169,10 @@ TEST_CASE("Core-Basic")
         REQUIRE(app_info.major_version == images::AppValidMajorVersion);
         REQUIRE(app_info.minor_version == images::AppValidMinorVersion);
         REQUIRE(app_info.vcs_commit    == images::AppValidVCSCommit);
+        REQUIRE(app_info.isReleaseBuild()    == images::AppValidReleaseBuild);   // NOLINT
+        REQUIRE(app_info.isDirtyBuild()      == images::AppValidDirtyBuild);     // NOLINT
+        REQUIRE(app_info.build_timestamp_utc == images::AppValidBuildTimestamp);
+        REQUIRE_FALSE(app_info.isBuildTimestampValid());
     };
     upload_valid_image();
 

--- a/test/test_popcop.cpp
+++ b/test/test_popcop.cpp
@@ -41,19 +41,277 @@
 #include "catch.hpp"
 #include "mocks.hpp"
 #include "images.hpp"
+#include "util.hpp"
 
 #include <thread>
 #include <numeric>
+#include <variant>
 #include <functional>
 #include <iostream>
 #include <utility>
 #include <sys/prctl.h>
 #include <csignal>
+#include <queue>
 
 
 namespace
 {
 
+class DuplexQueue
+{
+    mutable std::recursive_mutex mutex_;
+    std::queue<std::uint8_t> txq_;
+    std::queue<std::uint8_t> rxq_;
+
+    void pushAny(std::queue<std::uint8_t>& q, std::uint8_t byte)
+    {
+        std::lock_guard lock(mutex_);
+        q.push(byte);
+    }
+
+    std::optional<std::uint8_t> popAny(std::queue<std::uint8_t>& q)
+    {
+        std::lock_guard lock(mutex_);
+        if (!q.empty())
+        {
+            const auto ret = q.back();
+            q.pop();
+            return ret;
+        }
+        else
+        {
+            return {};
+        }
+    }
+
+public:
+    void pushTx(std::uint8_t byte) { pushAny(txq_, byte); }
+    void pushRx(std::uint8_t byte) { pushAny(rxq_, byte); }
+
+    std::optional<std::uint8_t> popTx() { return popAny(txq_); }
+    std::optional<std::uint8_t> popRx() { return popAny(rxq_); }
+
+    void reset()
+    {
+        std::lock_guard lock(mutex_);
+        txq_ = std::queue<std::uint8_t>();
+        rxq_ = std::queue<std::uint8_t>();
+    }
+};
+
+
+class Platform : public kocherga_popcop::IPopcopPlatform
+{
+    static constexpr std::chrono::seconds WatchdogTimeout{3};  // NOLINT
+
+    DuplexQueue& queue_;
+    bool should_exit_ = false;
+    std::vector<std::uint8_t> coa_;
+    std::chrono::steady_clock::time_point last_watchdog_reset_at_ = std::chrono::steady_clock::now();
+    kocherga::BootloaderController& blc_;
+    std::function<bool ()> exit_checker_;
+
+
+    void emit(std::uint8_t byte) override
+    {
+        queue_.pushTx(byte);
+    }
+
+    std::optional<std::uint8_t> receive() override
+    {
+        if (auto b = queue_.popRx())
+        {
+            return b;
+        }
+
+        std::this_thread::sleep_for(IOByteTimeout);
+        return queue_.popRx();
+    }
+
+    void processUnhandledFrame(const popcop::transport::ParserOutput::Frame& frame) override
+    {
+        std::cout << "Unhandled frame " << std::int32_t(frame.type_code) << ":\n"
+                  << util::makeHexDump(frame.payload) << std::endl;
+    }
+
+    void processExtraneousData(const std::uint8_t* data, std::size_t length) override
+    {
+        std::cout << "Extraneous data:\n" << util::makeHexDump(data, data + length) << std::endl;
+    }
+
+    popcop::standard::DeviceManagementCommandResponseMessage::Status processUnhandledDeviceManagementCommand(
+        const popcop::standard::DeviceManagementCommandRequestMessage& request) override
+    {
+        switch (request.command)
+        {
+        case popcop::standard::DeviceManagementCommand::Restart:
+        {
+            should_exit_ = true;
+            return popcop::standard::DeviceManagementCommandResponseMessage::Status::Ok;
+        }
+
+        case popcop::standard::DeviceManagementCommand::PowerOff:
+        case popcop::standard::DeviceManagementCommand::FactoryReset:
+        case popcop::standard::DeviceManagementCommand::PrintDiagnosticsBrief:
+        case popcop::standard::DeviceManagementCommand::PrintDiagnosticsVerbose:
+        {
+            return popcop::standard::DeviceManagementCommandResponseMessage::Status::BadCommand;
+        }
+
+        case popcop::standard::DeviceManagementCommand::LaunchBootloader:
+        {
+            throw std::logic_error("The command LaunchBootloader has not been intercepted by the bootloader");
+        }
+
+        default:
+        {
+            throw std::logic_error("Invalid command: " + std::to_string(std::uint32_t(request.command)));
+        }
+        }
+    }
+
+    std::int16_t writeAndReadBackCertificateOfAuthenticity(const std::uint8_t* in_data,
+                                                                 std::uint8_t* out_data,
+                                                                 std::uint8_t length) override
+    {
+        coa_.resize(length);
+        for (std::uint8_t i = 0; i < length; i++)
+        {
+            coa_.push_back(*(in_data + i));
+            *(out_data + i) = *(in_data + i);
+        }
+
+        return length;
+    }
+
+    void resetWatchdog() override
+    {
+        const auto n = std::chrono::steady_clock::now();
+        const auto dif = n - last_watchdog_reset_at_;
+        if (dif >= WatchdogTimeout)
+        {
+            throw std::logic_error("Watchdog would reset! Interval: " +
+                                   std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(dif).count()) +
+                                   " ms");
+        }
+
+        last_watchdog_reset_at_ = n;
+    }
+
+    bool shouldExit() const override
+    {
+        return should_exit_ || (blc_.getState() == kocherga::State::ReadyToBoot) || exit_checker_();
+    }
+
+public:
+    Platform(DuplexQueue& queue,
+             kocherga::BootloaderController& blc,
+             std::function<bool ()> exit_checker) :
+        queue_(queue),
+        blc_(blc),
+        exit_checker_(std::move(exit_checker))
+    {
+        if (!exit_checker_)
+        {
+            exit_checker_ = []() { return false; };
+        }
+    }
+};
+
+
+using AnyMessage = std::variant<popcop::standard::EndpointInfoMessage,
+                                popcop::standard::DeviceManagementCommandResponseMessage,
+                                popcop::standard::BootloaderStatusResponseMessage,
+                                popcop::standard::BootloaderImageDataResponseMessage>;
+
+class Modem
+{
+    DuplexQueue& q_;
+    popcop::transport::Parser<> parser_;
+
+    template <std::uint16_t OptionIndex = 0>
+    static std::optional<AnyMessage> decodeMessage(const popcop::transport::ParserOutput::Frame& frame)
+    {
+        if constexpr (OptionIndex < std::variant_size_v<AnyMessage>)
+        {
+            using MessageType = std::variant_alternative_t<OptionIndex, AnyMessage>;
+            if (auto msg = MessageType::tryDecode(frame.payload.begin(), frame.payload.end()))
+            {
+                return AnyMessage(*msg);
+            }
+            else
+            {
+                return decodeMessage<OptionIndex + 1U>(frame);
+            }
+        }
+        else
+        {
+            return {};
+        }
+    }
+
+    void pushRxQueue(std::uint8_t byte)
+    {
+        q_.pushRx(byte);
+    }
+
+    template <typename R, typename P>
+    std::optional<std::uint8_t> popTxQueue(std::chrono::duration<R, P> timeout)
+    {
+        if (auto b = q_.popTx())
+        {
+            return b;
+        }
+
+        std::this_thread::sleep_for(timeout);
+        return q_.popTx();
+    }
+public:
+    explicit Modem(DuplexQueue& queue) : q_(queue) { }
+
+    std::size_t send(const AnyMessage& msg)
+    {
+        return std::visit([this](auto m) -> std::size_t {
+            return m.encode(popcop::transport::StreamEmitter(popcop::presentation::StandardFrameTypeCode,
+                                                             [this](std::uint8_t x) { pushRxQueue(x); }).begin());
+        }, msg);
+    }
+
+    template <typename R, typename P>
+    std::optional<AnyMessage> receive(std::chrono::duration<R, P> timeout)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        do
+        {
+            if (auto ret = popTxQueue(std::chrono::milliseconds(1)))
+            {
+                const auto output = parser_.processNextByte(*ret);
+                if (auto frame = output.getReceivedFrame())
+                {
+                    const auto msg = decodeMessage(*frame);
+                    if (!msg)
+                    {
+                        throw std::logic_error("Unexpected frame with type code " +
+                                               std::to_string(std::int32_t(frame->type_code)));
+                    }
+
+                    return msg;
+                }
+                else if (auto data = output.getExtraneousData())
+                {
+                    throw std::logic_error("Extraneous data not expected");
+                }
+                else
+                {
+                    ;   // Nothing to do
+                }
+            }
+        }
+        while (std::chrono::steady_clock::now() <= deadline);
+
+        return {};
+    }
+};
 
 
 }  // namespace
@@ -61,7 +319,73 @@ namespace
 
 TEST_CASE("Popcop-Basic")
 {
+    volatile bool should_exit = false;
 
+    DuplexQueue queue;
+
+    std::thread endpoint_thread([&]() {
+        while (!should_exit)
+        {
+            std::cout << "Endpoint is (re)starting..." << std::endl;
+
+            mocks::Platform platform;
+            static constexpr std::uint32_t ROMSize = 1024 * 1024;
+            mocks::FileMappedROMBackend rom_backend("popcop-basic-rom.tmp", ROMSize);
+            kocherga::BootloaderController blc(platform, rom_backend, ROMSize);
+
+            popcop::standard::EndpointInfoMessage ep_info;
+
+            // The entire software version struct will be overwritten by the protocol implementation
+            ep_info.software_version.vcs_commit_id       = 0xdeadbeefUL;
+            ep_info.software_version.image_crc           = 0xbadc0ffeULL;
+            ep_info.software_version.dirty_build         = true;
+            ep_info.software_version.release_build       = true;
+            ep_info.software_version.build_timestamp_utc = 123456789UL;
+            ep_info.software_version.major               = 12;
+            ep_info.software_version.minor               = 34;
+
+            ep_info.hardware_version.major = 56;
+            ep_info.hardware_version.minor = 78;
+
+            ep_info.endpoint_name                   = "com.zubax.test";
+            ep_info.endpoint_description            = "Test Endpoint";
+            ep_info.build_environment_description   = "Build Environment";
+            ep_info.runtime_environment_description = "Runtime Environment";
+
+            ep_info.mode = popcop::standard::EndpointInfoMessage::Mode::Normal;   // Will be reset to Bootloader
+
+            ep_info.globally_unique_id = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}};
+
+            for (std::uint16_t i = 0; i < ep_info.certificate_of_authenticity.capacity(); i++)
+            {
+                ep_info.certificate_of_authenticity.push_back(std::uint8_t(i));
+            }
+
+            queue.reset();      // <--- mighty reset!
+
+            Platform popcop_platform(queue, blc, [&]() { return should_exit; });
+
+            kocherga_popcop::PopcopProtocol endpoint(blc, popcop_platform, ep_info);
+            endpoint.run();
+        }
+
+        std::cout << "Endpoint thread is exiting" << std::endl;
+    });
+
+    {
+        Modem modem(queue);
+
+        REQUIRE_FALSE(modem.receive(std::chrono::milliseconds(10)));
+    }
+
+    std::cout << "Joining the endpoint thread..." << std::endl;
+    should_exit = true;
+    if (endpoint_thread.joinable())
+    {
+        endpoint_thread.join();
+    }
+
+    std::cout << "Endpoint thread joined, test finished." << std::endl;
 }
 
 #endif // __clang__

--- a/test/test_popcop.cpp
+++ b/test/test_popcop.cpp
@@ -23,6 +23,11 @@
  * Author: Pavel Kirienko <pavel.kirienko@zubax.com>
  */
 
+// Skipping in case of Clang because it can't compile Popcop - the compiler is broken.
+// See the bug report here: https://bugs.llvm.org/show_bug.cgi?id=31852
+// TODO: This test should be re-enabled when a fixed version of Clang is available.
+#ifndef __clang__
+
 // We want to ensure that assertion checks are enabled when tests are run, for extra safety
 #ifdef NDEBUG
 # undef NDEBUG
@@ -56,3 +61,5 @@ TEST_CASE("Popcop-Basic")
 {
 
 }
+
+#endif // __clang__

--- a/test/test_popcop.cpp
+++ b/test/test_popcop.cpp
@@ -54,6 +54,8 @@
 namespace
 {
 
+
+
 }  // namespace
 
 

--- a/test/test_popcop.cpp
+++ b/test/test_popcop.cpp
@@ -556,8 +556,8 @@ TEST_CASE("Popcop-Basic")
     }
 
     // Upload finished! Waiting for the firmware to boot automatically
-    REQUIRE_FALSE(modem.receive(std::chrono::seconds(2)));    // Wait restart and ROM verification (takes time)
-    REQUIRE(num_restarts == 3);
+    REQUIRE_FALSE(modem.receive(std::chrono::seconds(2)));      // Wait restart and ROM verification (takes time)
+    REQUIRE(num_restarts == 3);                                 // After restart, the mock ROM is erased
 
     /*
      * Finalize

--- a/test/test_popcop.cpp
+++ b/test/test_popcop.cpp
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Zubax Robotics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+ */
+
+// We want to ensure that assertion checks are enabled when tests are run, for extra safety
+#ifdef NDEBUG
+# undef NDEBUG
+#endif
+
+#define KOCHERGA_TRACE          std::printf
+
+// The library headers must be included first to make sure that they don't have any hidden include dependencies.
+#include <kocherga_popcop.hpp>
+
+#include "catch.hpp"
+#include "mocks.hpp"
+#include "images.hpp"
+
+#include <thread>
+#include <numeric>
+#include <functional>
+#include <iostream>
+#include <utility>
+#include <sys/prctl.h>
+#include <csignal>
+
+
+namespace
+{
+
+}  // namespace
+
+
+TEST_CASE("Popcop-Basic")
+{
+
+}

--- a/test/test_uavcan_python.cpp
+++ b/test/test_uavcan_python.cpp
@@ -45,7 +45,6 @@
 #include <functional>
 #include <iostream>
 #include <utility>
-#include <test/libcanard/canard.h>
 #include <sys/prctl.h>
 #include <csignal>
 

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -29,12 +29,12 @@
 
 TEST_CASE("Util-HexDump")
 {
-    REQUIRE("00000000  31 32 33                                          123             \n"
+    REQUIRE("00000000  31 32 33                                          123             "
             == util::makeHexDump(std::string("123")));
 
     REQUIRE("00000000  30 31 32 33 34 35 36 37  38 39 61 62 63 64 65 66  0123456789abcdef\n"
             "00000010  67 68 69 6a 6b 6c 6d 6e  6f 70 71 72 73 74 75 76  ghijklmnopqrstuv\n"
             "00000020  77 78 79 7a 41 42 43 44  45 46 47 48 49 4a 4b 4c  wxyzABCDEFGHIJKL\n"
-            "00000030  4d 4e 4f 50 51 52 53 54  55 56 57 58 59 5a        MNOPQRSTUVWXYZ  \n"
+            "00000030  4d 4e 4f 50 51 52 53 54  55 56 57 58 59 5a        MNOPQRSTUVWXYZ  "
             == util::makeHexDump(std::string("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")));
 }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Zubax Robotics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+ */
+
+#include "util.hpp"
+#include "catch.hpp"
+
+
+TEST_CASE("Util-HexDump")
+{
+    REQUIRE("00000000  31 32 33                                          123             \n"
+            == util::makeHexDump(std::string("123")));
+
+    REQUIRE("00000000  30 31 32 33 34 35 36 37  38 39 61 62 63 64 65 66  0123456789abcdef\n"
+            "00000010  67 68 69 6a 6b 6c 6d 6e  6f 70 71 72 73 74 75 76  ghijklmnopqrstuv\n"
+            "00000020  77 78 79 7a 41 42 43 44  45 46 47 48 49 4a 4b 4c  wxyzABCDEFGHIJKL\n"
+            "00000030  4d 4e 4f 50 51 52 53 54  55 56 57 58 59 5a        MNOPQRSTUVWXYZ  \n"
+            == util::makeHexDump(std::string("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")));
+}

--- a/test/util.hpp
+++ b/test/util.hpp
@@ -40,17 +40,27 @@ inline std::string makeHexDump(InputIterator begin, const InputIterator end)
     static constexpr std::uint8_t BytesPerRow = 16;
     std::uint32_t offset = 0;
     std::ostringstream output;
+    bool first = true;
 
     output << std::hex << std::setfill('0');
 
     do
     {
+        if (first)
+        {
+            first = false;
+        }
+        else
+        {
+            output << std::endl;
+        }
+
         output << std::setw(8) << offset << "  ";
         offset += BytesPerRow;
 
         {
             auto it = begin;
-            for (unsigned i = 0; i < BytesPerRow; ++i)
+            for (std::uint8_t i = 0; i < BytesPerRow; ++i)
             {
                 if (i == 8)
                 {
@@ -59,7 +69,7 @@ inline std::string makeHexDump(InputIterator begin, const InputIterator end)
 
                 if (it != end)
                 {
-                    output << std::setw(2) << unsigned(*it) << ' ';
+                    output << std::setw(2) << std::uint32_t(*it) << ' ';
                     ++it;
                 }
                 else
@@ -70,11 +80,11 @@ inline std::string makeHexDump(InputIterator begin, const InputIterator end)
         }
 
         output << " ";
-        for (unsigned i = 0; i < BytesPerRow; ++i)
+        for (std::uint8_t i = 0; i < BytesPerRow; ++i)
         {
             if (begin != end)
             {
-                output << ((unsigned(*begin) >= 32U && unsigned(*begin) <= 126U) ? char(*begin) : '.');
+                output << ((std::uint32_t(*begin) >= 32U && std::uint32_t(*begin) <= 126U) ? char(*begin) : '.');
                 ++begin;
             }
             else
@@ -82,8 +92,6 @@ inline std::string makeHexDump(InputIterator begin, const InputIterator end)
                 output << ' ';
             }
         }
-
-        output << std::endl;
     }
     while (begin != end);
 

--- a/test/util.hpp
+++ b/test/util.hpp
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Zubax Robotics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <sstream>
+#include <iomanip>
+#include <cstdint>
+
+
+namespace util
+{
+
+template <typename InputIterator>
+inline std::string makeHexDump(InputIterator begin, const InputIterator end)
+{
+    static constexpr std::uint8_t BytesPerRow = 16;
+    std::uint32_t offset = 0;
+    std::ostringstream output;
+
+    output << std::hex << std::setfill('0');
+
+    do
+    {
+        output << std::setw(8) << offset << "  ";
+        offset += BytesPerRow;
+
+        {
+            auto it = begin;
+            for (unsigned i = 0; i < BytesPerRow; ++i)
+            {
+                if (i == 8)
+                {
+                    output << ' ';
+                }
+
+                if (it != end)
+                {
+                    output << std::setw(2) << unsigned(*it) << ' ';
+                    ++it;
+                }
+                else
+                {
+                    output << "   ";
+                }
+            }
+        }
+
+        output << " ";
+        for (unsigned i = 0; i < BytesPerRow; ++i)
+        {
+            if (begin != end)
+            {
+                output << ((unsigned(*begin) >= 32U && unsigned(*begin) <= 126U) ? char(*begin) : '.');
+                ++begin;
+            }
+            else
+            {
+                output << ' ';
+            }
+        }
+
+        output << std::endl;
+    }
+    while (begin != end);
+
+    return output.str();
+}
+
+
+template <typename Container>
+inline std::string makeHexDump(const Container& cont)
+{
+    return makeHexDump(std::begin(cont), std::end(cont));
+}
+
+}  // namespace util


### PR DESCRIPTION
Also, the AppInfo struct has been extended in a backward-compatible way to support additional optional information:

- `uint32_t build_timestamp_utc` - UTC Unix time in seconds when the application was built
- release build flag
- dirty build flag