### PR TITLE
Fix processing data from uavcan.protocol.file.Read

### DIFF
--- a/kocherga/kocherga_can.hpp
+++ b/kocherga/kocherga_can.hpp
@@ -1250,7 +1250,7 @@ private:
                                         const std::size_t         response_size,
                                         const std::uint8_t* const response_data)
     {
-        if (response_size >= 4)
+        if (response_size >= 2)
         {
             std::array<std::uint8_t, 270> buf{};
             buf.back()     = 0xAA;


### PR DESCRIPTION
An empty response to the `uavcan.protocol.file.Read` will have a size of 2 bytes (this is the size of the error field), while the DroneCAN -> Cyphal converter expects at least 4, because it mistakenly assumes that the minimum response size will be like in Cyphal, where there is no tail array optimization.